### PR TITLE
feat: add image service

### DIFF
--- a/src/app/service/image/image.service.go
+++ b/src/app/service/image/image.service.go
@@ -1,0 +1,34 @@
+package image
+
+import (
+	"context"
+	"time"
+
+	proto "github.com/isd-sgcu/johnjud-go-proto/johnjud/file/image/v1"
+	"github.com/rs/zerolog/log"
+)
+
+type Service struct {
+	client proto.ImageServiceClient
+}
+
+func NewService(client proto.ImageServiceClient) *Service {
+	return &Service{client: client}
+}
+
+func (s *Service) FindByPetId(petId string) ([]*proto.Image, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := s.client.FindByPetId(ctx, &proto.FindImageByPetIdRequest{PetId: petId})
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("service", "image").
+			Str("module", "find by petId").
+			Msg("Error while connecting to service")
+		return nil, err
+	}
+	return res.Images, nil
+
+}

--- a/src/app/service/image/image.service_test.go
+++ b/src/app/service/image/image.service_test.go
@@ -1,0 +1,68 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/bxcodec/faker/v3"
+	mock "github.com/isd-sgcu/johnjud-backend/src/mocks/image"
+	proto "github.com/isd-sgcu/johnjud-go-proto/johnjud/file/image/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type ImageServiceTest struct {
+	suite.Suite
+	petId  string
+	images []*proto.Image
+}
+
+func TestImageService(t *testing.T) {
+	suite.Run(t, new(ImageServiceTest))
+}
+
+func (t *ImageServiceTest) SetupTest() {
+	t.petId = faker.UUIDDigit()
+	t.images = []*proto.Image{
+		{
+			Id:       faker.UUIDDigit(),
+			PetId:    t.petId,
+			ImageUrl: faker.URL(),
+		},
+		{
+			Id:       faker.UUIDDigit(),
+			PetId:    t.petId,
+			ImageUrl: faker.URL(),
+		},
+	}
+}
+
+func (t *ImageServiceTest) TestFindByPetIdSuccess() {
+	want := t.images
+
+	c := mock.ClientMock{}
+	c.On("FindByPetId", &proto.FindImageByPetIdRequest{PetId: t.petId}).
+		Return(&proto.FindImageByPetIdResponse{Images: t.images}, nil)
+
+	srv := NewService(&c)
+	actual, err := srv.FindByPetId(t.petId)
+
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), want, actual)
+}
+
+func (t *ImageServiceTest) TestFindByPetIdError() {
+	c := mock.ClientMock{}
+	c.On("FindByPetId", &proto.FindImageByPetIdRequest{PetId: t.petId}).
+		Return(&proto.FindImageByPetIdResponse{Images: t.images}, status.Error(codes.Unavailable, "Connection Timeout"))
+
+	srv := NewService(&c)
+	actual, err := srv.FindByPetId(t.petId)
+
+	st, ok := status.FromError(err)
+	assert.True(t.T(), ok)
+	assert.Nil(t.T(), actual)
+	assert.Equal(t.T(), codes.Unavailable, st.Code())
+}

--- a/src/mocks/image/image.mock.go
+++ b/src/mocks/image/image.mock.go
@@ -1,0 +1,57 @@
+package image
+
+import (
+	"context"
+
+	proto "github.com/isd-sgcu/johnjud-go-proto/johnjud/file/image/v1"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc"
+)
+
+type ClientMock struct {
+	mock.Mock
+}
+
+func (c *ClientMock) Upload(_ context.Context, in *proto.UploadImageRequest, _ ...grpc.CallOption) (res *proto.UploadImageResponse, err error) {
+	args := c.Called(in)
+
+	if args.Get(0) != nil {
+		res = args.Get(0).(*proto.UploadImageResponse)
+	}
+
+	return res, args.Error(1)
+}
+
+func (c *ClientMock) FindByPetId(_ context.Context, in *proto.FindImageByPetIdRequest, _ ...grpc.CallOption) (res *proto.FindImageByPetIdResponse, err error) {
+	args := c.Called(in)
+
+	if args.Get(0) != nil {
+		res = args.Get(0).(*proto.FindImageByPetIdResponse)
+	}
+
+	return res, args.Error(1)
+}
+
+func (c *ClientMock) Delete(_ context.Context, in *proto.DeleteImageRequest, _ ...grpc.CallOption) (res *proto.DeleteImageResponse, err error) {
+	args := c.Called(in)
+
+	if args.Get(0) != nil {
+		res = args.Get(0).(*proto.DeleteImageResponse)
+	}
+
+	return res, args.Error(1)
+}
+
+type ServiceMock struct {
+	mock.Mock
+}
+
+func (c *ServiceMock) FindByPetId(petId string) (res []*proto.Image, err error) {
+	args := c.Called(petId)
+
+	if args.Get(0) != nil {
+		res = args.Get(0).([]*proto.Image)
+	}
+
+	return res, args.Error(1)
+}


### PR DESCRIPTION
- image service (as service that points to client in johnjud-file's image service)
- image service and client mocks
- image service tests